### PR TITLE
Added host and schemes support

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,4 +38,3 @@ function getArgs() {
     };
 }
 exports.getArgs = getArgs;
-//# sourceMappingURL=cli.js.map

--- a/bin/lib/index.js
+++ b/bin/lib/index.js
@@ -6,4 +6,3 @@ var httpSwaggerProvider_1 = require("./swaggerProvider/httpSwaggerProvider");
 exports.HttpSwaggerProvider = httpSwaggerProvider_1.HttpSwaggerProvider;
 var logger_1 = require("./logger");
 exports.logger = logger_1.logger;
-//# sourceMappingURL=index.js.map

--- a/bin/lib/logger.js
+++ b/bin/lib/logger.js
@@ -10,4 +10,3 @@ class Logger {
     }
 }
 exports.logger = new Logger();
-//# sourceMappingURL=logger.js.map

--- a/bin/lib/operation/operation.js
+++ b/bin/lib/operation/operation.js
@@ -48,4 +48,3 @@ class Operation {
     }
 }
 exports.Operation = Operation;
-//# sourceMappingURL=operation.js.map

--- a/bin/lib/operation/operationsBuilder.js
+++ b/bin/lib/operation/operationsBuilder.js
@@ -54,4 +54,3 @@ class OperationsBuilder {
     }
 }
 exports.OperationsBuilder = OperationsBuilder;
-//# sourceMappingURL=operationsBuilder.js.map

--- a/bin/lib/parsers/lambdaParser/IAst.js
+++ b/bin/lib/parsers/lambdaParser/IAst.js
@@ -1,3 +1,2 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-//# sourceMappingURL=IAst.js.map

--- a/bin/lib/parsers/lambdaParser/parser.generated.js
+++ b/bin/lib/parsers/lambdaParser/parser.generated.js
@@ -544,4 +544,3 @@ module.exports = {
     SyntaxError: peg$SyntaxError,
     parse: peg$parse,
 };
-//# sourceMappingURL=parser.generated.js.map

--- a/bin/lib/parsers/parserWrapper.js
+++ b/bin/lib/parsers/parserWrapper.js
@@ -9,4 +9,3 @@ class ParserWrapper {
     }
 }
 exports.ParserWrapper = ParserWrapper;
-//# sourceMappingURL=parserWrapper.js.map

--- a/bin/lib/parsers/parsers.js
+++ b/bin/lib/parsers/parsers.js
@@ -5,4 +5,3 @@ const lambdaParserGen = require("./lambdaParser/parser.generated");
 const typeNameParserGen = require("./typeNameParser/parser.generated");
 exports.lambdaParser = new parserWrapper_1.ParserWrapper(lambdaParserGen.parse);
 exports.typeNameParser = new parserWrapper_1.ParserWrapper(typeNameParserGen.parse);
-//# sourceMappingURL=parsers.js.map

--- a/bin/lib/parsers/typeNameParser/IAst.js
+++ b/bin/lib/parsers/typeNameParser/IAst.js
@@ -1,3 +1,2 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-//# sourceMappingURL=IAst.js.map

--- a/bin/lib/parsers/typeNameParser/parser.generated.js
+++ b/bin/lib/parsers/typeNameParser/parser.generated.js
@@ -572,4 +572,3 @@ module.exports = {
     SyntaxError: peg$SyntaxError,
     parse: peg$parse,
 };
-//# sourceMappingURL=parser.generated.js.map

--- a/bin/lib/renderer/helpers.js
+++ b/bin/lib/renderer/helpers.js
@@ -110,4 +110,3 @@ function changeCaseHelper(context, toCase, options) {
     }
 }
 exports.changeCaseHelper = changeCaseHelper;
-//# sourceMappingURL=helpers.js.map

--- a/bin/lib/renderer/operationsGroupRenderer.js
+++ b/bin/lib/renderer/operationsGroupRenderer.js
@@ -35,4 +35,3 @@ class OperationsGroupRender extends renderer_1.AbstractRenderer {
     }
 }
 exports.OperationsGroupRender = OperationsGroupRender;
-//# sourceMappingURL=operationsGroupRenderer.js.map

--- a/bin/lib/renderer/renderer.js
+++ b/bin/lib/renderer/renderer.js
@@ -70,4 +70,3 @@ class AbstractRenderer {
     }
 }
 exports.AbstractRenderer = AbstractRenderer;
-//# sourceMappingURL=renderer.js.map

--- a/bin/lib/renderer/typesDefinitionRender.js
+++ b/bin/lib/renderer/typesDefinitionRender.js
@@ -26,4 +26,3 @@ class TypesDefinitionRender extends renderer_1.AbstractRenderer {
     }
 }
 exports.TypesDefinitionRender = TypesDefinitionRender;
-//# sourceMappingURL=typesDefinitionRender.js.map

--- a/bin/lib/settings.js
+++ b/bin/lib/settings.js
@@ -64,4 +64,3 @@ function loadSettings(configFile = null, override = {}) {
     return exports.settings;
 }
 exports.loadSettings = loadSettings;
-//# sourceMappingURL=settings.js.map

--- a/bin/lib/swaggerProvider/fsSwaggerProvider.js
+++ b/bin/lib/swaggerProvider/fsSwaggerProvider.js
@@ -24,4 +24,3 @@ class FsSwaggerProvider {
     }
 }
 exports.FsSwaggerProvider = FsSwaggerProvider;
-//# sourceMappingURL=fsSwaggerProvider.js.map

--- a/bin/lib/swaggerProvider/httpSwaggerProvider.js
+++ b/bin/lib/swaggerProvider/httpSwaggerProvider.js
@@ -37,4 +37,3 @@ class HttpSwaggerProvider {
     }
 }
 exports.HttpSwaggerProvider = HttpSwaggerProvider;
-//# sourceMappingURL=httpSwaggerProvider.js.map

--- a/bin/lib/swaggerProvider/swaggerProvider.js
+++ b/bin/lib/swaggerProvider/swaggerProvider.js
@@ -14,4 +14,3 @@ function getProvider() {
     }
 }
 exports.getProvider = getProvider;
-//# sourceMappingURL=swaggerProvider.js.map

--- a/bin/lib/tsFromSwagger.js
+++ b/bin/lib/tsFromSwagger.js
@@ -34,6 +34,8 @@ class TsFromSwagger {
     }
     adjustSwaggerPaths(swagger) {
         let base = swagger.basePath;
+        let host = swagger.host;
+        let schemes = swagger.schemes;
         const newPaths = {};
         if (base && base.endsWith('/')) {
             base = base.substring(0, base.length - 2);
@@ -77,6 +79,15 @@ class TsFromSwagger {
                 }
                 fixedPath = base + fixedPath;
             }
+            fixedPath = (host !== undefined) ? host + fixedPath : fixedPath;
+            if (schemes !== undefined && schemes.length > 0) {
+                if (schemes.filter(function (x) { return x.toLowerCase() == "https"; })) {
+                    fixedPath = "https://" + fixedPath;
+                }
+                else {
+                    fixedPath = "http://" + fixedPath;
+                }
+            }
             newPaths[fixedPath] = swagger.paths[p];
         });
         swagger.paths = newPaths;
@@ -118,4 +129,3 @@ class TsFromSwagger {
     }
 }
 exports.TsFromSwagger = TsFromSwagger;
-//# sourceMappingURL=tsFromSwagger.js.map

--- a/bin/lib/type/type.js
+++ b/bin/lib/type/type.js
@@ -24,4 +24,3 @@ class Type {
     }
 }
 exports.Type = Type;
-//# sourceMappingURL=type.js.map

--- a/bin/lib/type/typeBuilder.js
+++ b/bin/lib/type/typeBuilder.js
@@ -63,4 +63,3 @@ class TypeBuilder {
     }
 }
 exports.TypeBuilder = TypeBuilder;
-//# sourceMappingURL=typeBuilder.js.map

--- a/bin/lib/type/typeNameInfo.js
+++ b/bin/lib/type/typeNameInfo.js
@@ -158,4 +158,3 @@ TypeNameInfo.primitiveTypesMapping = {
     "string+password": "string",
 };
 exports.TypeNameInfo = TypeNameInfo;
-//# sourceMappingURL=typeNameInfo.js.map

--- a/bin/lib/utils/deepMerge.js
+++ b/bin/lib/utils/deepMerge.js
@@ -33,4 +33,3 @@ function isExtendable(val) {
     return typeof val !== "undefined" && val !== null &&
         (typeof val === "object" || typeof val === "function");
 }
-//# sourceMappingURL=deepMerge.js.map

--- a/bin/lib/utils/fsUtil.js
+++ b/bin/lib/utils/fsUtil.js
@@ -46,4 +46,3 @@ function createIfnotExists(outPath) {
     });
 }
 exports.createIfnotExists = createIfnotExists;
-//# sourceMappingURL=fsUtil.js.map

--- a/bin/main.js
+++ b/bin/main.js
@@ -27,4 +27,3 @@ main()
 }).catch((error) => {
     lib_2.logger.error(error);
 });
-//# sourceMappingURL=main.js.map

--- a/src/lib/tsFromSwagger.ts
+++ b/src/lib/tsFromSwagger.ts
@@ -20,9 +20,11 @@ export class TsFromSwagger {
     }
     private async getSwagger() {
        return await getProvider().provide(settings, logger);
-        }
+    }
     private adjustSwaggerPaths(swagger: Swagger.Spec) {
         let base = swagger.basePath;
+        let host: string = swagger.host;
+        let schemes = swagger.schemes;
         const newPaths: {[pathName: string]: Swagger.Path} = {};
 
         if (base && base.endsWith('/')) {
@@ -70,6 +72,16 @@ export class TsFromSwagger {
                 }
 
                 fixedPath = base + fixedPath;
+            }
+
+            fixedPath = (host !== undefined) ? host + fixedPath : fixedPath;
+
+            if(schemes !== undefined && schemes.length > 0){
+                if(schemes.filter(function(x) {return x.toLowerCase() == "https"})){
+                    fixedPath = "https://" + fixedPath;
+                } else {
+                    fixedPath = "http://" + fixedPath;
+                }
             }
 
             newPaths[fixedPath] = swagger.paths[p];

--- a/templates/operationsGroup.handlebars
+++ b/templates/operationsGroup.handlebars
@@ -24,7 +24,7 @@ export class {{operationGroup.operationsGroupName}} {
         return new Promise<{{responsesType}}>((resolve, reject) => {
             request
             .{{httpVerb}}(`{{url}}`)
-            {{#some operationParams "op=>!op.inBody"}}
+            {{#some operationParams "op=>(!op.inBody && !op.inPath)"}}
             .query(params)
             {{/some}}
             {{#filterList operationParams "op=>op.inBody" "1"}}


### PR DESCRIPTION
I've added the host and schemes to the URL output if they are presented in the swagger.

I've not bound the host and schemes output to each other which maybe I should have, if you'd prefer that please let me know.

Just fixed the issue where path params would cause query(params) to be added to the request rather than only being constraint to inUrl (Note it might be worth switching the if so it only returns url querystring params rather than excluding specific ones as I think headers and formdata will also cause this bug)

I'm not sure what your preferences are with coding styles so hope this is ok.